### PR TITLE
Removed subprocess calls and replaced it with function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,15 @@ Or use the new autorun tool by double clicking run_lipsick.bat
 
 This will launch a Gradio interface where you can upload your video and audio files to process them with LipSick.
 
-
+You can also run the following command: 
+```bash
+python inference.py --source_video_path /home/ubuntu/Downloads/black_stussy.mp4 
+--driving_audio_path /home/ubuntu/Downloads/stussy_text.wav 
+--pretrained_lipsick_path /home/ubuntu/code/LipSick/asserts/pretrained_lipsick.pth 
+--deepspeech_model_path /home/ubuntu/code/LipSick/asserts/output_graph.pb 
+--res_video_dir /home/ubuntu/code/LipSick/asserts/inference_result/ 
+--custom_reference_frames ref_indices_str
+```
 
 
 

--- a/inference.py
+++ b/inference.py
@@ -12,16 +12,20 @@ import shutil
 import warnings
 import tensorflow as tf
 
-warnings.filterwarnings("ignore", category=UserWarning, message="Default grid_sample and affine_grid behavior has changed*")
+warnings.filterwarnings("ignore", category=UserWarning,
+                        message="Default grid_sample and affine_grid behavior has changed*")
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '1'
 
 from utils.deep_speech import DeepSpeech
 from utils.data_processing import compute_crop_radius
 from config.config import LipSickInferenceOptions
-from models.LipSick import LipSick  # Import the LipSick model
+from models.LipSick import LipSick
+from utils.blend import extract_frames_from_video as blend_extract_frames_from_video, \
+    blend_videos  # Import blend functions
 
 face_detector = dlib.get_frontal_face_detector()
 landmark_predictor = dlib.shape_predictor("./models/shape_predictor_68_face_landmarks.dat")
+
 
 def get_versioned_filename(filepath):
     base, ext = os.path.splitext(filepath)
@@ -31,12 +35,14 @@ def get_versioned_filename(filepath):
         counter += 1
     return filepath
 
+
 def convert_audio_to_wav(audio_path):
     output_path = os.path.splitext(audio_path)[0] + '.wav'
     if not audio_path.lower().endswith('.wav'):
         command = f'ffmpeg -i "{audio_path}" -acodec pcm_s16le -ar 16000 -ac 1 "{output_path}"'
         subprocess.run(command, shell=True, check=True)
     return output_path
+
 
 def extract_frames_from_video(video_path, save_dir):
     video_capture = cv2.VideoCapture(video_path)
@@ -49,6 +55,7 @@ def extract_frames_from_video(video_path, save_dir):
         cv2.imwrite(result_path, frame)
     return (int(video_capture.get(cv2.CAP_PROP_FRAME_WIDTH)), int(video_capture.get(cv2.CAP_PROP_FRAME_HEIGHT)))
 
+
 def load_landmark_dlib(image_path):
     img = cv2.imread(image_path)
     gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
@@ -59,6 +66,7 @@ def load_landmark_dlib(image_path):
     landmarks = np.array([[p.x, p.y] for p in shape.parts()])
     return landmarks
 
+
 def parse_reference_indices(indices_str):
     try:
         indices = list(map(int, indices_str.split(',')))
@@ -68,18 +76,18 @@ def parse_reference_indices(indices_str):
         print("Error parsing reference indices.")
     return []
 
+
 if __name__ == '__main__':
     opt = LipSickInferenceOptions().parse_args()
     opt.driving_audio_path = convert_audio_to_wav(opt.driving_audio_path)
 
-    # Ensure the res_video_dir is defined before using it
     res_video_dir = opt.res_video_dir
 
     if not os.path.exists(opt.source_video_path):
         raise Exception(f'Wrong video path: {opt.source_video_path}')
     if not os.path.exists(opt.deepspeech_model_path):
         raise Exception('Please download the pretrained model of deepspeech')
-    
+
     print('Extracting frames from video')
     video_frame_dir = opt.source_video_path.replace('.mp4', '')
     if not os.path.exists(video_frame_dir):
@@ -100,6 +108,7 @@ if __name__ == '__main__':
     video_frame_path_list_cycle = video_frame_path_list + video_frame_path_list[::-1]
     video_landmark_data_cycle = np.concatenate([video_landmark_data, np.flip(video_landmark_data, 0)], 0)
     video_frame_path_list_cycle_length = len(video_frame_path_list_cycle)
+
     if video_frame_path_list_cycle_length >= res_frame_length:
         res_video_frame_path_list = video_frame_path_list_cycle[:res_frame_length]
         res_video_landmark_data = video_landmark_data_cycle[:res_frame_length, :, :]
@@ -107,8 +116,10 @@ if __name__ == '__main__':
         divisor = res_frame_length // video_frame_path_list_cycle_length
         remainder = res_frame_length % video_frame_path_list_cycle_length
         res_video_frame_path_list = video_frame_path_list_cycle * divisor + video_frame_path_list_cycle[:remainder]
-        res_video_landmark_data = np.concatenate([video_landmark_data_cycle] * divisor + [video_landmark_data_cycle[:remainder, :, :]], 0)
-    res_video_frame_path_list_pad = [video_frame_path_list_cycle[0]] * 2 + res_video_frame_path_list + [video_frame_path_list_cycle[-1]] * 2
+        res_video_landmark_data = np.concatenate(
+            [video_landmark_data_cycle] * divisor + [video_landmark_data_cycle[:remainder, :, :]], 0)
+    res_video_frame_path_list_pad = [video_frame_path_list_cycle[0]] * 2 + res_video_frame_path_list + [
+        video_frame_path_list_cycle[-1]] * 2
     res_video_landmark_data_pad = np.pad(res_video_landmark_data, ((2, 2), (0, 0), (0, 0)), mode='edge')
     assert ds_feature_padding.shape[0] == len(res_video_frame_path_list_pad) == res_video_landmark_data_pad.shape[0]
     pad_length = ds_feature_padding.shape[0]
@@ -131,14 +142,16 @@ if __name__ == '__main__':
         if opt.custom_crop_radius and opt.custom_crop_radius > 0:
             crop_radius, crop_flag = opt.custom_crop_radius, True
         else:
-            crop_flag, crop_radius = compute_crop_radius(video_size, res_video_landmark_data_pad[ref_index - 5:ref_index, :, :])
+            crop_flag, crop_radius = compute_crop_radius(video_size,
+                                                         res_video_landmark_data_pad[ref_index - 5:ref_index, :, :])
 
         crop_radius_1_4 = crop_radius // 4
         ref_img = cv2.imread(res_video_frame_path_list_pad[ref_index - 3])[:, :, ::-1]
         ref_landmark = res_video_landmark_data_pad[ref_index - 3, :, :]
         ref_img_crop = ref_img[
                        ref_landmark[29, 1] - crop_radius:ref_landmark[29, 1] + crop_radius * 2 + crop_radius // 4,
-                       ref_landmark[33, 0] - crop_radius - crop_radius // 4:ref_landmark[33, 0] + crop_radius + crop_radius // 4,
+                       ref_landmark[33, 0] - crop_radius - crop_radius // 4:ref_landmark[
+                                                                                33, 0] + crop_radius + crop_radius // 4,
                        ]
         ref_img_crop = cv2.resize(ref_img_crop, (resize_w, resize_h))
         ref_img_crop = ref_img_crop / 255.0
@@ -152,34 +165,36 @@ if __name__ == '__main__':
     state_dict = torch.load(opt.pretrained_lipsick_path, map_location=torch.device('cpu'))['state_dict']['net_g']
     new_state_dict = OrderedDict()
     for k, v in state_dict.items():
-        name = k[7:] 
+        name = k[7:]
         new_state_dict[name] = v
     model.load_state_dict(new_state_dict)
     model.eval()
 
     res_video_name = os.path.basename(opt.source_video_path)[:-4] + '_facial_dubbing.mp4'
     res_video_path = os.path.join(opt.res_video_dir, res_video_name)
-    res_video_path = get_versioned_filename(res_video_path)  # Ensure unique filename
+    res_video_path = get_versioned_filename(res_video_path)
 
     videowriter = cv2.VideoWriter(res_video_path, cv2.VideoWriter_fourcc(*'mp4v'), 25, video_size)
 
     if opt.auto_mask:
         samelength_video_name = 'samelength.mp4'
         samelength_video_path = os.path.join(opt.res_video_dir, samelength_video_name)
-        samelength_video_path = get_versioned_filename(samelength_video_path)  # Ensure unique filename
+        samelength_video_path = get_versioned_filename(samelength_video_path)
         videowriter_samelength = cv2.VideoWriter(samelength_video_path, cv2.VideoWriter_fourcc(*'mp4v'), 25, video_size)
 
     res_face_name = os.path.basename(opt.source_video_path)[:-4] + '_facial_dubbing_face.mp4'
     res_face_path = os.path.join(opt.res_video_dir, res_face_name)
-    res_face_path = get_versioned_filename(res_face_path)  # Ensure unique filename
+    res_face_path = get_versioned_filename(res_face_path)
 
     videowriter_face = cv2.VideoWriter(res_face_path, cv2.VideoWriter_fourcc(*'mp4v'), 25, (resize_w, resize_h))
 
     for clip_end_index in range(5, pad_length, 1):
         sys.stdout.write(f'\rSynthesizing {clip_end_index - 5}/{pad_length - 5} frame')
-        sys.stdout.flush()  # Make sure to flush the output buffer
+        sys.stdout.flush()
         if not crop_flag:
-            crop_radius = compute_crop_radius(video_size, res_video_landmark_data_pad[clip_end_index - 5:clip_end_index, :, :], random_scale=1.10)
+            crop_radius = compute_crop_radius(video_size,
+                                              res_video_landmark_data_pad[clip_end_index - 5:clip_end_index, :, :],
+                                              random_scale=1.10)
 
         crop_radius_1_4 = crop_radius // 4
         frame_data = cv2.imread(res_video_frame_path_list_pad[clip_end_index - 3])[:, :, ::-1]
@@ -189,7 +204,8 @@ if __name__ == '__main__':
         frame_landmark = res_video_landmark_data_pad[clip_end_index - 3, :, :]
         crop_frame_data = frame_data[
                           frame_landmark[29, 1] - crop_radius:frame_landmark[29, 1] + crop_radius * 2 + crop_radius_1_4,
-                          frame_landmark[33, 0] - crop_radius - crop_radius_1_4:frame_landmark[33, 0] + crop_radius + crop_radius_1_4,
+                          frame_landmark[33, 0] - crop_radius - crop_radius_1_4:frame_landmark[
+                                                                                    33, 0] + crop_radius + crop_radius_1_4,
                           ]
         crop_frame_h, crop_frame_w = crop_frame_data.shape[0], crop_frame_data.shape[1]
         crop_frame_data = cv2.resize(crop_frame_data, (resize_w, resize_h)) / 255.0
@@ -197,7 +213,9 @@ if __name__ == '__main__':
         opt.mouth_region_size // 8:opt.mouth_region_size // 8 + opt.mouth_region_size, :] = 0
 
         crop_frame_tensor = torch.from_numpy(crop_frame_data).float().to('cuda').permute(2, 0, 1).unsqueeze(0)
-        deepspeech_tensor = torch.from_numpy(ds_feature_padding[clip_end_index - 5:clip_end_index, :]).permute(1, 0).unsqueeze(0).float().to('cuda')
+        deepspeech_tensor = torch.from_numpy(ds_feature_padding[clip_end_index - 5:clip_end_index, :]).permute(1,
+                                                                                                               0).unsqueeze(
+            0).float().to('cuda')
 
         with torch.no_grad():
             pre_frame = model(crop_frame_tensor, ref_img_tensor, deepspeech_tensor)
@@ -217,26 +235,34 @@ if __name__ == '__main__':
     videowriter_face.release()
 
     if opt.auto_mask:
-        video_add_audio_path = os.path.join(opt.res_video_dir, 'pre_blend.mp4')
+        print('Auto Mask stage')
+
+        same_length_dir = os.path.join(opt.res_video_dir, 'samelength')
+        if not os.path.exists(same_length_dir):
+            os.makedirs(same_length_dir)
+        blend_extract_frames_from_video(samelength_video_path, same_length_dir)
+
+        pre_blend_dir = os.path.join(opt.res_video_dir, 'pre_blend')
+        if not os.path.exists(pre_blend_dir):
+            os.makedirs(pre_blend_dir)
+        blend_extract_frames_from_video(res_face_path, pre_blend_dir)
+
+        final_video_path = blend_videos(same_length_dir, pre_blend_dir, samelength_video_path, res_face_path)
+
+        os.remove(res_video_path)
+        os.remove(res_face_path)
+
     else:
-        video_add_audio_path = os.path.join(opt.res_video_dir, os.path.basename(opt.source_video_path)[:-4] + '_LIPSICK.mp4')
-
-    video_add_audio_path = get_versioned_filename(video_add_audio_path)  # Ensure unique filename
-
-    cmd = f'ffmpeg -r 25 -i "{res_video_path}" -i "{opt.driving_audio_path}" -c:v copy -c:a aac -strict experimental -map 0:v:0 -map 1:a:0 "{video_add_audio_path}"'
-    subprocess.call(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # Suppress FFmpeg logs
-    os.remove(res_video_path)  # Clean up intermediate files
-    os.remove(res_face_path)  # Clean up intermediate files
+        video_add_audio_path = os.path.join(opt.res_video_dir,
+                                            os.path.basename(opt.source_video_path)[:-4] + '_LIPSICK.mp4')
+        video_add_audio_path = get_versioned_filename(video_add_audio_path)
+        cmd = f'ffmpeg -r 25 -i "{res_video_path}" -i "{opt.driving_audio_path}" -c:v copy -c:a aac -strict experimental -map 0:v:0 -map 1:a:0 "{video_add_audio_path}"'
+        subprocess.call(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        os.remove(res_video_path)
+        os.remove(res_face_path)
 
     if opt.auto_mask:
-        print('Auto Mask stage')
-        samelength_video_path = os.path.join(opt.res_video_dir, 'samelength.mp4')
-        pre_blend_video_path = os.path.join(opt.res_video_dir, 'pre_blend.mp4')
-
-        # Call blend.py for blending and masking
-        cmd = [
-            'python', 'utils/blend.py',
-            '--samelength_video_path', samelength_video_path,
-            '--pre_blend_video_path', pre_blend_video_path
-        ]
-        subprocess.call(cmd, shell=True)
+        video_add_audio_path = os.path.join(opt.res_video_dir, 'pre_blend.mp4')
+        video_add_audio_path = get_versioned_filename(video_add_audio_path)
+        cmd = f'ffmpeg -r 25 -i "{final_video_path}" -i "{opt.driving_audio_path}" -c:v copy -c:a aac -strict experimental -map 0:v:0 -map 1:a:0 "{video_add_audio_path}"'
+        subprocess.call(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/utils/blend.py
+++ b/utils/blend.py
@@ -8,35 +8,13 @@ import dlib
 import subprocess
 import shutil
 
-# Add the parent directory to the Python path explicitly
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.append(parent_dir)
 
-# Now import from the utils module
 from utils.common import get_versioned_filename
 
 face_detector = dlib.get_frontal_face_detector()
 landmark_predictor = dlib.shape_predictor("./models/shape_predictor_68_face_landmarks.dat")
-
-def main(samelength_path, pre_blend_path):
-    # Extract frames from the samelength video
-    print('Extracting frames from samelength video')
-    same_length_dir = os.path.join(os.path.dirname(samelength_path), 'samelength')
-    if not os.path.exists(same_length_dir):
-        os.makedirs(same_length_dir)
-    extract_frames_from_video(samelength_path, same_length_dir)
-
-    # Extract frames from the pre_blend video
-    print('Extracting frames from pre_blend video')
-    pre_blend_dir = os.path.join(os.path.dirname(pre_blend_path), 'pre_blend')
-    if not os.path.exists(pre_blend_dir):
-        os.makedirs(pre_blend_dir)
-    extract_frames_from_video(pre_blend_path, pre_blend_dir)
-
-    print('Tracking Face of Lip-synced (LipSick) video please wait..')
-
-    # Call the blending function
-    blend_videos(same_length_dir, pre_blend_dir, samelength_path, pre_blend_path)
 
 def extract_frames_from_video(video_path, save_dir):
     videoCapture = cv2.VideoCapture(video_path)
@@ -74,7 +52,6 @@ def alpha_blend_face(original_frame, generated_frame, landmarks):
     return blended_frame.astype(np.uint8)
 
 def blend_videos(same_length_dir, pre_blend_dir, samelength_path, pre_blend_path):
-    # Get frames from both videos
     same_length_frame_path_list = glob.glob(os.path.join(same_length_dir, '*.jpg'))
     same_length_frame_path_list.sort()
 
@@ -82,16 +59,15 @@ def blend_videos(same_length_dir, pre_blend_dir, samelength_path, pre_blend_path
     pre_blend_frame_path_list.sort()
     pre_blend_landmark_data = np.array([load_landmark_dlib(frame) for frame in pre_blend_frame_path_list])
 
-    # Blend frames from pre_blend video onto samelength video using Alpha blending
     output_video_path = samelength_path.replace('samelength.mp4', '_lipsick_blend.mp4')
-    output_video_path = get_versioned_filename(output_video_path)  # Ensure unique filename
+    output_video_path = get_versioned_filename(output_video_path)
     video_size = (int(cv2.VideoCapture(samelength_path).get(cv2.CAP_PROP_FRAME_WIDTH)),
                   int(cv2.VideoCapture(samelength_path).get(cv2.CAP_PROP_FRAME_HEIGHT)))
     videowriter = cv2.VideoWriter(output_video_path, cv2.VideoWriter_fourcc(*'mp4v'), 25, video_size)
 
     for i, (same_length_frame_path, pre_blend_frame_path, landmark_data) in enumerate(zip(same_length_frame_path_list, pre_blend_frame_path_list, pre_blend_landmark_data)):
         sys.stdout.write(f'\rAlpha blending frame {i+1}/{len(same_length_frame_path_list)}')
-        sys.stdout.flush()  # Make sure to flush the output buffer
+        sys.stdout.flush()
 
         same_length_frame = cv2.imread(same_length_frame_path)
         pre_blend_frame = cv2.imread(pre_blend_frame_path)
@@ -100,27 +76,37 @@ def blend_videos(same_length_dir, pre_blend_dir, samelength_path, pre_blend_path
             blended_frame = alpha_blend_face(same_length_frame, pre_blend_frame, landmark_data)
         except ValueError as e:
             print(f"Skipping frame {i+1} due to error: {e}")
-            blended_frame = same_length_frame  # Use original frame if blending fails
+            blended_frame = same_length_frame
 
         videowriter.write(blended_frame)
 
     videowriter.release()
 
-    # Store the output video path for later use
-    output_video_path = output_video_path
-
-    # Add audio to the blended video
     final_video_path = get_versioned_filename(output_video_path.replace('_lipsick_blend.mp4', 'LipSick_Blend.mp4'))
 
     cmd = f'ffmpeg -i "{output_video_path}" -i "{pre_blend_path}" -c:v libx264 -crf 23 -c:a aac -strict experimental "{final_video_path}"'
     subprocess.call(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-    # Clean up intermediate files
     os.remove(output_video_path)
     os.remove(samelength_path)
     os.remove(pre_blend_path)
     shutil.rmtree(same_length_dir)
     shutil.rmtree(pre_blend_dir)
+
+    return final_video_path
+
+def main(samelength_path, pre_blend_path):
+    same_length_dir = os.path.join(os.path.dirname(samelength_path), 'samelength')
+    if not os.path.exists(same_length_dir):
+        os.makedirs(same_length_dir)
+    extract_frames_from_video(samelength_path, same_length_dir)
+
+    pre_blend_dir = os.path.join(os.path.dirname(pre_blend_path), 'pre_blend')
+    if not os.path.exists(pre_blend_dir):
+        os.makedirs(pre_blend_dir)
+    extract_frames_from_video(pre_blend_path, pre_blend_dir)
+
+    blend_videos(same_length_dir, pre_blend_dir, samelength_path, pre_blend_path)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Alpha blend two videos based on facial landmarks')


### PR DESCRIPTION
This is a fix that removes the subprocess calls in your `inference.py` and `utils/blend.py` scripts. 

I made this because it gave me issues where the terminal would open an instance of python, not finishing the lip sync. 

`ffmpeg` calls remain via a subprocess call, as this is not a problem.